### PR TITLE
Case sensitive directory name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ ISRELEASED          = False
 VERSION             = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 
-def write_version_py(filename='pyqrnative/version.py'):
+def write_version_py(filename='PyQRNative/version.py'):
 
     try:
         gitfile = open('.git/refs/heads/master', 'r')


### PR DESCRIPTION
Attempting to install via pip or directly from source on linux results in:

IOError: [Errno 2] No such file or directory: 'pyqrnative/version.py'

This appears to be due to the destination directory specified inconsistent with the module case. This is a non-fail on windows, but breaks on linux.
